### PR TITLE
Modify file to use the correct path without the .exe extension

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby.exe
+#!/usr/bin/env ruby
 APP_PATH = File.expand_path("../config/application", __dir__)
 require_relative "../config/boot"
 require "rails/commands"


### PR DESCRIPTION
- Modify file to use the correct path without the .exe extension to solve /usr/bin/env: ‘ruby.exe’: No such file or directory issue.
